### PR TITLE
docs: full project review & prioritised fix plan (doc/review-26-07-04.md)

### DIFF
--- a/doc/review-26-07-04.md
+++ b/doc/review-26-07-04.md
@@ -1,0 +1,259 @@
+# cui-portal-core — Full Project Review & Fix Plan
+
+**Date:** 2026-07-04
+**Reviewed version:** `1.5-SNAPSHOT` (parent `de.cuioss:cui-java-parent:1.4.4`)
+**Scope:** All 11 Maven modules (main + test), documentation, build/CI, dependencies.
+**Method:** Six parallel deep-review passes (authentication, core, micro-profile/test-infra, documentation, build/CI/dependencies, cross-cutting) plus a full `./mvnw clean verify -Ppre-commit` ground-truth build. Headline security findings were independently re-verified against source.
+
+> **This document is a plan only.** It records findings and hints for fixing, and partitions the remediation work into sensible, independently-mergeable pull requests. No production code is changed by this document. The actual fixing is out of scope for this session.
+
+---
+
+## 1. Executive summary
+
+The codebase is **mature and unusually disciplined**. Several whole risk-categories came back completely clean:
+
+- No `TODO`/`FIXME`/`XXX`/`HACK` markers, no `@Deprecated` debt.
+- No `System.out`/`System.err`/`printStackTrace`, no string concatenation inside log calls.
+- 295/295 Java files carry the Apache-2.0 license header.
+- No committed secrets, no hardcoded production URLs/paths, no static mutable state in main code (all `static` fields are `static final`).
+- Every dependency version is centrally managed (no hardcoded versions); all GitHub Actions are pinned to full commit SHAs with least-privilege `permissions:` blocks; Dependabot, dependency-review and Scorecards are wired up.
+
+The findings that matter cluster into a few areas:
+
+| Theme | Highest severity | Where |
+|---|---|---|
+| **OAuth login-flow security** | HIGH | `portal-authentication-oauth` |
+| **Credentials/secrets leaking into logs** | HIGH | oauth, `portal-configuration`, `portal-mp-rest-client` |
+| **Cache metrics silently broken** | HIGH | `portal-metrics-api` |
+| **Concurrency / visibility (FileWatcher, lazy init)** | HIGH | `portal-configuration`, `portal-common-cdi` |
+| **Broken/dead public contracts** | HIGH | `portal-common-cdi` (`PortalBeanManager`) |
+| **Disabled & flaky tests** | HIGH | `portal-configuration`, `portal-core` (#121), `portal-mp-rest-client` |
+| **Doc ↔ code drift (LogMessages, READMEs, groupId)** | HIGH (doc) | multiple |
+| **Build/POM hygiene** | MEDIUM | root POM, `micro-profile` |
+
+### Build ground truth
+`./mvnw clean verify -Ppre-commit` compiles cleanly with **zero warnings**. The build fails on exactly **one** test: `HostnameVerificationTest.incorrectHostname` (`portal-mp-rest-client`), which asserts `assertNotEquals("localhost", InetAddress.getLocalHost().getCanonicalHostName())`. In sandboxed/containerised environments the canonical hostname *is* `localhost`, so the test is environment-fragile (and misnamed — it uses a *correct* CN). This is captured as finding **T-1**. All other tests pass.
+
+### Related existing work (do not duplicate)
+- **Issue #121** — flaky `ExternalHostnameProducerTest` DEBUG-log assertions. Folded into **PR-8**.
+- **PR #132 / #133** — Dependabot/release-bot bump `cui-java-parent` 1.4.4 → 1.4.5. Let those land independently; **PR-11** should rebase on top rather than re-do the bump.
+
+### Severity legend
+- **HIGH** — security impact, data-corruption/visibility bug, broken public contract, or a build/coverage blind spot masking the above.
+- **MEDIUM** — real defect with limited blast radius, or a contract/documentation mismatch that will mislead callers.
+- **LOW** — hygiene, cosmetics, minor doc gaps, defensive hardening.
+
+---
+
+## 2. Remediation plan — PR clusters
+
+Work is partitioned into **11 PRs**. Ordering reflects priority and dependencies. Security PRs (P0) first; each PR is scoped to avoid touching files another PR touches, so they can proceed in parallel where noted.
+
+| PR | Title | Priority | Depends on | Primary module(s) |
+|----|-------|----------|-----------|-------------------|
+| PR-1 | OAuth login-flow security hardening | **P0** | — | portal-authentication-oauth |
+| PR-2 | Stop leaking credentials into logs | **P0** | — | portal-configuration, portal-mp-rest-client |
+| PR-3 | FileWatcher concurrency + re-enable disabled tests | **P1** | — | portal-configuration |
+| PR-4 | portal-common-cdi correctness & contract fixes | **P1** | — | portal-common-cdi |
+| PR-5 | portal-core servlet correctness | **P1** | — | portal-core |
+| PR-6 | Fix broken cache metrics | **P1** | — | portal-metrics-api |
+| PR-7 | Test-infrastructure hardening | **P2** | — | portal-core-unit-testing |
+| PR-8 | Test reliability / flaky & fragile tests | **P1** | — | portal-core, portal-mp-rest-client |
+| PR-9 | LogMessages: dedupe identifiers & remove dead records | **P2** | PR-1 (oauth part) | oauth, metrics, mock |
+| PR-10 | Documentation accuracy | **P2** | PR-9 | all (docs only) |
+| PR-11 | Build / POM / CI hygiene | **P2** | #132/#133 | root, micro-profile, bom, .github |
+
+> **Sequencing notes.** PR-1 and PR-2 are the release blockers — do them first. PR-9 fixes the OAuth duplicate log identifiers in code, so it should merge *after* PR-1 (which also touches the oauth LogMessages class for the state-warning); coordinate to avoid a conflict, or fold the oauth log-dedup into PR-1 and drop it from PR-9. PR-10 (docs) should merge after PR-9 so the regenerated `LogMessages.md` reflects the corrected identifiers.
+
+---
+
+### PR-1 — OAuth login-flow security hardening  · **P0**
+Module: `modules/authentication/portal-authentication-oauth`
+
+| # | Sev | File:line | Finding | Fix hint |
+|---|-----|-----------|---------|----------|
+| S-1 | **HIGH** | `impl/Oauth2AuthenticationFacadeImpl.java:254-291` | **`state` (CSRF) is not enforced.** On state mismatch the code sets `sessionUser = null` and *continues* to exchange the code and log the user in; it only aborts when `STATE_KEY` is entirely absent (`:250`). Enables login-CSRF / auth-code injection. *Verified against source.* | On mismatch: `LOGGER.warn(WARN.INVALID_STATE, …)` and `return Optional.empty()` (or throw `OauthAuthenticationException`) **before** the token exchange. |
+| S-1b | **HIGH** | `impl/Oauth2AuthenticationFacadeImplTest.java:359-373` | Test `loginWithStateMismatch` asserts `result.isAuthenticated()==true` and its comment documents the insecure behavior — it locks the vulnerability in. | Invert the test to assert the login is rejected once S-1 is fixed. |
+| S-2 | **HIGH** | `impl/Oauth2DiscoveryConfigurationProducer.java:170` (also `:219,:223`); `impl/Oauth2ConfigurationImpl.java:54,67` | **Client secret logged.** `Oauth2ConfigurationImpl` is `@Data`, so `LOGGER.debug("Configuration created: %s", configuration)` renders `clientSecret`. DEBUG is commonly enabled. *Verified.* | Add `@ToString.Exclude` to `clientSecret` (and `clientId`), or stop logging the whole object. |
+| S-3 | MEDIUM | `oauth/Token.java:42,55,62,69`; used at `impl/Oauth2ServiceImpl.java:187-188,217-218,309` | **Tokens logged.** `Token` is `@Data`; `access_token`/`refresh_token`/`id_token` appear in `toString` (TRACE), and `access_token` is logged directly. *Verified.* | `@ToString.Exclude` the three token fields (add a masked custom `toString`); drop the raw `access_token` trace line. |
+| S-4 | MEDIUM | `impl/Oauth2AuthenticationFacadeImpl.java:428` (cf. correct `:325`) | **Wrong Base64 alphabet for JWT payload.** Uses `Base64.getDecoder()`; JWT segments are base64**url**. Real id_tokens with `-`/`_` throw and yield an empty claim map. *Verified.* | Use `Base64.getUrlDecoder()`. Add a test with url-safe chars in the payload. |
+| S-5 | MEDIUM | `impl/Oauth2AuthenticationFacadeImpl.java:517-537` | **NPE when user has no token.** If `getToken()` is null, `checkToken(null,…)` is false, then `!MoreStrings.isEmpty(token.getRefresh_token())` dereferences null. Reachable via public `retrieveToken(...)`. | Guard `token != null` before the refresh branch; add a null-token test. |
+| S-6 | MEDIUM | `impl/Oauth2AuthenticationFacadeImpl.java:304-305,335` | **Nonce generated & sent but never validated**, though the class Javadoc (`:76,:101`) advertises "Nonce validation". | Implement nonce check against the id_token `nonce` claim in `handleTriggerAuthenticate`, or remove the false claim from the Javadoc. |
+| S-7 | LOW | `impl/OauthAuthenticatedUserInfo.java:116`; `impl/Oauth2AuthenticationFacadeImpl.java:454-455` | Unboxing NPEs: `(Integer) …get(TOKEN_TIMESTAMP_KEY)` / `getTokenTimestamp()` unbox to `int`; `retrieveRenewInterval` dereferences `getToken()`. | Null-guard before unboxing / dereferencing. |
+| S-8 | LOW | `oauth/Oauth2AuthenticationFacade.java:92-97` vs impl `:454-456` | Javadoc says renew interval is in **milliseconds**; code computes **seconds**. | Fix the Javadoc (or the unit). |
+| S-9 | LOW | `src/main/resources/META-INF/microprofile-config.properties:47-48` | Comment says "Defaults to 'false'" but the property is set to `true`. | Correct the comment. |
+| S-10 | LOW | `impl/Oauth2AuthenticationFacadeImpl.java:424` | Per-call `new ObjectMapper()`. | Reuse a `static final` reader. |
+| S-11 | MEDIUM | `impl/Oauth2ServiceImpl.java:189-198,251-255,287-291,317-321` | Return-`null`-on-exception across 4 methods; loses failure context and forces null-checks. | Prefer `Optional`/typed result, or document the null contract. |
+| S-12 | LOW | `impl/Oauth2AuthenticationFacadeImpl.java:233-237,321-322,487-488` | Log-and-throw (double-logging risk). | Log **or** throw, not both. |
+| S-13 | LOW | `impl/Oauth2ServiceImplTest.java:100,221-226` | Stale test name `deprecatedCreateAuthenticatedUserInfo` (method gone); `shouldRetrieveAuthenticatedUser` asserts on the setup user, not the result. | Rename/repair assertions. |
+
+---
+
+### PR-2 — Stop leaking credentials into logs  · **P0**
+Modules: `portal-configuration`, `portal-mp-rest-client`
+
+| # | Sev | File:line | Finding | Fix hint |
+|---|-----|-----------|---------|----------|
+| L-1 | **HIGH** | `portal-configuration/.../impl/initializer/PortalConfigurationLogger.java:96-101` | **Weak redaction.** `filterPassword` only masks keys literally containing `password`/`Password`; it logs the entire system-property/env/portal config at INFO. `DB_PASSWORD` (uppercase) is **not** matched, and `secret`/`token`/`key`/`credential`/`pwd` are never filtered. | Match case-insensitively (`toLowerCase(Locale.ROOT)`); extend deny-list: `secret, token, key, credential, pwd, passwd`. Add tests for uppercase & each keyword. |
+| L-2 | MEDIUM | `portal-mp-rest-client/.../LogClientRequestFilter.java:62-78` (+ `LogReaderInterceptor`, `LogClientResponseFilter`) | Serializes **all** request/response headers — including `Authorization` — at INFO when trace-logging is enabled. Bearer tokens / basic creds land in INFO logs. | Redact `Authorization` (and `Cookie`/`Set-Cookie`) before logging; consider emitting at TRACE. |
+| L-3 | LOW | `portal-mp-rest-client/.../BasicAuthenticationFilter.java:60`; `BearerTokenAuthFilter.java:47` | `LOGGER.trace("Using auth header %s", authHeader)` logs the (decodable) Base64 basic header; `LOGGER.trace("token: %s", token)` logs the raw bearer token. | Remove, or log only a masked/length indicator. |
+
+---
+
+### PR-3 — FileWatcher concurrency + re-enable disabled tests  · **P1**
+Module: `modules/core/portal-configuration`
+
+| # | Sev | File:line | Finding | Fix hint |
+|---|-----|-----------|---------|----------|
+| C-1 | **HIGH** | `impl/schedule/FileWatcherServiceImpl.java:96,83` | `upAndRunning` (worker loop `while (upAndRunning)` `:213`) and `watcherService` are non-`volatile`, written by the CDI thread and read by the executor thread. Worker may never observe `destroy()`; may see partially-published `watcherService`. *Independently flagged by two reviewers.* | Declare both `volatile` (or guard with a lock). |
+| C-2 | **HIGH** | `impl/schedule/FileWatcherServiceImplEnabledTest.java:105,115`; `FileWatcherServiceImplRecursiveTest.java:76` | The core change-detection / recursive-watch tests are `@Disabled("...async calls block after the migration...")`. The most concurrency-sensitive component has its event delivery untested. | Restore with Awaitility; would also surface C-1. |
+| C-3 | MEDIUM | `impl/schedule/AbstractFileDescriptor.java:99` | `register(watcherService, ENTRY_MODIFY, ENTRY_DELETE, ENTRY_DELETE)` passes `ENTRY_DELETE` twice and never `ENTRY_CREATE`; newly created files emit no native event. | Change the duplicate to `ENTRY_CREATE`. |
+| C-4 | MEDIUM | `connections/impl/ConnectionMetadata.java:253-262` | `resolveSSLContext()` lazily inits non-`volatile` `sslContext` with unsynchronized check-then-act; class advertises thread-safety. | `volatile` + double-checked locking, or synchronize. |
+| C-5 | LOW | `connections/impl/ConnectionMetadata.java:58` | `@EqualsAndHashCode` includes the lazily-populated transient `sslContext` (no value `equals`), so equal instances compare unequal once one resolves. | Exclude `sslContext`; reconsider mutable keystore fields. |
+| C-6 | LOW | `impl/schedule/DirectoryDescriptor.java:65-79,100-106` | `lastModifiedHash` accumulated as an additive sum of `lastModified()` via a side-effect in `fileList()`; collision-prone. | Use a real checksum; drop the field-mutation-as-side-effect. |
+| C-7 | LOW | `connections/impl/ConnectionMetadataProducer.java:255-281` vs `:229-253` | Keystore location not validated with `MorePaths.checkReadablePath(...)` while truststore is. | Add the same validation. |
+| C-8 | LOW | `impl/schedule/FileWatcherServiceImpl.java:146-159,158,225` | `destroy()` never `awaitTermination`; log grammar "was successfully"; prose "clumsy" interruption-handling note at `:225`. | Confirm shutdown / fix grammar / resolve or ticket the note. |
+
+---
+
+### PR-4 — portal-common-cdi correctness & contract fixes  · **P1**
+Module: `modules/core/portal-common-cdi`
+
+| # | Sev | File:line | Finding | Fix hint |
+|---|-----|-----------|---------|----------|
+| K-1 | **HIGH** | `cdi/PortalBeanManager.java:~152,~168` | `getCDIBean`→`checkBeanTypesFound` throws `IllegalArgumentException` on not-found, so `resolveBean`'s documented `Optional.empty()` is unreachable and the `Portal-532 IllegalStateException` in `resolveBeanOrThrow...` is dead. Broken public contract. | Return null on not-found so `Optional`/`orElseThrow` work as documented; add tests for both paths. |
+| K-2 | MEDIUM | `cdi/AnnotationInstanceProvider.java:~158,~261` | `equals` NPEs on `proxy.equals(null)`; `hashCode` violates `Annotation.hashCode()` spec (returns 0 on null members) → proxies won't hash-equal real annotations. | Null-guard `equals`; implement the spec formula. |
+| K-3 | MEDIUM | `stage/ProjectStage.java:78` | `name().toLowerCase()` uses default locale (Turkish-`i` hazard). | `toLowerCase(Locale.ROOT)`. |
+| K-4 | MEDIUM | `bundle/ResourceBundleWrapperImpl.java:136-148,162-172,131` | Lazy `resolvedBundles` init is non-`volatile`/unsynchronized while `keySet()` is `@Synchronized` and an event thread nulls the field (`@SessionScoped`, multi-tab). `keyList` cached but never cleared on `LocaleChangeEvent`. Observer method typo `actOnLocaleChangeEven`. | Make `resolvedBundles` volatile / synchronize consistently; clear `keyList` on locale change; fix the method name. |
+| K-5 | LOW | `util/PortalResourceLoader.java:68` | `getContextClassLoader()` may be null → NPE. | Null-check / fall back to the class's own loader. |
+| K-6 | MEDIUM | `bundle/ResourceBundleRegistry.java:~109/138`; `bundle/ResourceBundleLocator.java:96-117`; `priority/PortalPriorities.java:~99` | Javadoc/behavior mismatches: `@throws IllegalStateException` (only logs warn); default `getBundle` Javadoc copied from a non-Optional signature; `sortByPriority` documents `@throws NPE` but null-guards. | Align each Javadoc with actual behavior. |
+| K-7 | LOW | `bundle/PortalResourceBundleBean.java` | Javadoc claims thread-safe; lazy `resourceBundleWrapper` init is unsynchronized check-then-act on a non-volatile field. | Make volatile or correct the claim. |
+
+---
+
+### PR-5 — portal-core servlet correctness  · **P1**
+Module: `modules/core/portal-core`
+
+| # | Sev | File:line | Finding | Fix hint |
+|---|-----|-----------|---------|----------|
+| P-1 | MEDIUM | `listener/ServletLifecycleListener.java:97-106` | `contextInitialized` runs `applicationInitializer.initialize()` in a loop **without** try/catch (the destroy loop `:121-127` does catch). One failing initializer aborts all later ones — contradicts "Handles initialization errors gracefully". | Wrap each `initialize()` in try/catch, or fail-fast intentionally and update the doc. |
+| P-2 | LOW | `servlet/ExternalHostnameProducer.java:60` | `X_FORWARDED_PROTO` constant declared but never used. Also: hostname built from client-controlled `X-Forwarded-Host` with no allow-listing — safe as display, risky if used for redirect/absolute URLs. | Remove the dead constant; add a Javadoc caveat about the header's trust boundary. |
+| P-3 | LOW | `user/PortalUserProducer.java:62-71` | Class Javadoc says "application scoped" but the class is `@RequestScoped`. | Fix the doc. |
+| P-4 | LOW | `servlet/AbstractPortalServlet.java:98-109` | Only `doGet`/`executeDoGet` is access-checked; a subclass overriding `doPost`/`doPut` bypasses `checkAccess`. | Document the limitation prominently (or template the other verbs). |
+| P-5 | LOW | `storage/impl/MapStorageImpl.java:61-62` | `@ToString`/`@EqualsAndHashCode` over storage that may hold sensitive session data → possible leak in logs. | Exclude values from `toString`, or document. |
+
+---
+
+### PR-6 — Fix broken cache metrics  · **P1**
+Module: `modules/micro-profile/portal-metrics-api`
+
+| # | Sev | File:line | Finding | Fix hint |
+|---|-----|-----------|---------|----------|
+| M-1 | **HIGH** | `metrics/CaffeineCacheMetrics.java:157-175` | **All 11 stat gauges report a frozen snapshot.** Registered as `cache.stats()::hitRate` etc.; `cache.stats()` (an immutable value object) is evaluated once at `bindTo` time, so hitRate/hitCount/missCount/... are pinned to their registration values (all zero for a fresh cache). Only `estimatedSize`/`getSize` update. Metrics are effectively broken in production. | Use lambdas that re-read on each poll: `() -> cache.stats().hitRate()`, etc. |
+| M-2 | LOW | `metrics/CaffeineCacheMetricsTest.java:47-63` | Test asserts only gauge *count* and name prefix — never a gauge value, which is why M-1 went undetected. | Populate the cache and assert `hitCount`/`missCount` reflect activity. |
+| M-3 | MEDIUM | `metrics/utils/MetricsUtils.java:67-68,82-108` | `metricsAppName`/`metricsAppTag` are mutable `static`, lazily inited without synchronization → data race + value cached for JVM lifetime (config changes never reflected). `MetricUtilsTest` resets them via reflection — direct evidence of the leak. | Resolve on each call, or use a lock/holder; avoid mutable static state in a `@UtilityClass`. |
+| M-4 | LOW | `metrics/utils/MetricsUtils.java:136-146` | Javadoc omits `@param exceptionTagMappers`. | Add it. |
+| M-5 | LOW | `metrics/PortalMetricsLogMessages.java:78-82` | `INFO.CACHE_METRICS_REMOVED` (003) is defined but never used (no removal method). | Wire it up or remove it. |
+| M-6 | **HIGH (doc)** | `doc/LogMessages.md:13-18,22-25` | Documents `Portal-Metrics-100/-101` (WARN) and `-200/-201` (ERROR) that **do not exist** — code has only INFO 001-003. Four fabricated entries. | Remove the WARN/ERROR tables (or add the LogRecords if intended). *(Doc-only; may also ride in PR-10, but keep near M-5.)* |
+
+---
+
+### PR-7 — Test-infrastructure hardening  · **P2**
+Module: `modules/test/portal-core-unit-testing`
+
+| # | Sev | File:line | Finding | Fix hint |
+|---|-----|-----------|---------|----------|
+| I-1 | MEDIUM | `mocks/configuration/PortalTestConfiguration.java:129,105-110,162-188` | `properties` is `static final` → shared across every Weld container/test class in the JVM; isolation depends entirely on the extension's `clear()`. Javadoc also describes a "delta map" that does not exist (removal is a plain `Map.remove`, not a tombstone). | Make `properties` a non-static instance field (bean is `@ApplicationScoped`); rewrite the stale Javadoc. |
+| I-2 | LOW | `mocks/configuration/FileWatcherServiceMock.java:44-46,91-98,111,138` | Javadoc claims "Thread-safe … Uses HashSet for thread-safe path storage" but the store is a plain `HashSet`; `fireEvent`'s `@param path` is empty. | Use a concurrent set or correct the docs; fill the `@param`. |
+| I-3 | LOW | `mocks/microprofile/PortalTestMetricRegistry.java:113-114,497-500,145,222-278` | Javadoc example uses `getMetrics().containsKey(...)` but `getMetrics()` always returns empty; many overrides return `null` vs the documented `UnsupportedOperationException`; `NOT_IMPLEMENTED_EXCEPTION` is a shared singleton (stack trace from class-init). | Make the contract consistent; fix the example. |
+| I-4 | LOW | `mocks/authentication/PortalAuthenticationFacadeMock.java:63-91,189-191` | Javadoc references non-existent `authenticate(...)`/`getCurrentAuthenticationContext()`; `doLogin()` calls `login(...)` but discards the result and never updates `current` → no effect. Several bare `@param` tags. | Fix the Javadoc; make `doLogin()` actually update state. |
+| I-5 | LOW | `tests/configuration/AbstractConfigurationKeyVerifierTest.java:207-209` | `field.get(null)` read twice for the same field. | Reuse the first read. |
+| I-6 | LOW | `tests/BaseModuleConsistencyTest.java:88-100`; `tests/BaseAssemblyConsistencyTest.java:89-101` | `@Test` methods declared `protected` — unusual, can surprise tooling. | Make package-private/`public`. |
+
+---
+
+### PR-8 — Test reliability / flaky & fragile tests  · **P1**
+Modules: `portal-core`, `portal-mp-rest-client`
+
+| # | Sev | File:line | Finding | Fix hint |
+|---|-----|-----------|---------|----------|
+| T-1 | **HIGH** | `portal-mp-rest-client/.../HostnameVerificationTest.java:55-76` | **Currently fails the build in containerised envs.** `assertNotEquals("localhost", InetAddress.getLocalHost().getCanonicalHostName())` (`:64`) — canonical hostname *is* `localhost` in sandboxes. The test is also misnamed: `incorrectHostname` uses a *correct* CN (`commonName(hostname)`) and never exercises a hostname mismatch nor the `isDisableHostNameVerification()` branch (`CuiRestClientBuilder:158-161`). | Make the hostname deterministic (skip/guard when it resolves to `localhost`, or bind to a fixed test host); rename; add a real negative test that exercises a CN mismatch and the disable-verification branch. |
+| T-2 | HIGH | `portal-core/.../servlet/ExternalHostnameProducerTest.java` (all 9 DEBUG-log-asserting methods) | Flaky DEBUG-log assertions — **issue #121**. Static-logger vs test-handler race across per-invocation Weld containers. | Per #121: drop the log assertions (behavior already covered by `assertEquals`), or reset the test-logger handler in `@BeforeEach`, or move log assertions to a single-container non-parameterized test. |
+
+> Note: `Oauth2ServiceImplTest`/`Oauth2AuthenticationFacadeImplTest` weak-assertion items live in **PR-1** (S-1b, S-13) to keep oauth test edits in one PR.
+
+---
+
+### PR-9 — LogMessages: dedupe identifiers & remove dead records  · **P2**
+Modules: `portal-authentication-oauth`, `portal-metrics-api`, `portal-authentication-mock`
+Depends on PR-1 (coordinate the oauth LogMessages edits).
+
+| # | Sev | File:line | Finding | Fix hint |
+|---|-----|-----------|---------|----------|
+| G-1 | MEDIUM | `oauth/.../PortalAuthenticationOauthLogMessages.java` | **Duplicate identifiers:** `identifier(201)` on both `REDIRECT_FAILED` and `CODE_CHALLENGE_GENERATION_FAILED`; `identifier(202)` on both `LOGOUT_FAILED` and `TOKEN_EXPIRES_IN_INVALID`. Breaks the unique-id convention used by log assertions. | Re-number to unique ids; then regenerate `doc/LogMessages.md` (see D-8). |
+| G-2 | LOW | same file | Large set of **dead LogRecords** never referenced: `INFO.CONFIG_CREATED`, `WARN.MISSING_PARAMETERS`, `WARN.INVALID_STATE`*, `WARN.NO_SCOPES_IN_SESSION`, `WARN.NO_TOKEN_RECEIVED`, `WARN.NO_USERINFO_RECEIVED`, `ERROR.REDIRECT_FAILED`, `ERROR.CODE_CHALLENGE_GENERATION_FAILED`, `ERROR.LOGOUT_FAILED`, `ERROR.TOKEN_EXPIRES_IN_INVALID`, `ERROR.INVALID_SCOPE`, `ERROR.LOGIN_ERROR`, `ERROR.UNEXPECTED_LOGIN_CALL`, `ERROR.ERROR_DURING_AUTHENTICATION`. | Remove the truly-dead records. *`WARN.INVALID_STATE` becomes used by PR-1/S-1 — keep it.* |
+| G-3 | LOW | `metrics/PortalMetricsLogMessages.java:78-82` | Dead `INFO.CACHE_METRICS_REMOVED` (= M-5). | Remove or wire up (coordinate with PR-6). |
+
+---
+
+### PR-10 — Documentation accuracy  · **P2**  (docs only)
+Depends on PR-9 so regenerated LogMessages reflect corrected ids.
+
+| # | Sev | File | Finding | Fix hint |
+|---|-----|------|---------|----------|
+| D-1 | MEDIUM | `modules/core/README.adoc:7-8` | Lists only `portal-common-cdi` & `portal-core`; **`portal-configuration` is missing**. | Add `* link:portal-configuration/[portal-configuration]`. |
+| D-2 | HIGH | `modules/micro-profile/portal-mp-rest-client/README.adoc:10` | `groupId de.cuioss.portal.core.micro-profile` is wrong — actual is `de.cuioss.portal.mirco-profile`. Copy-pasting the coordinates fails. | Correct the groupId (align with PR-11 if the typo is fixed). |
+| D-3 | MEDIUM | `modules/authentication/portal-authentication-api/README.adoc:43-50,73-78,148` | Interface snippets out of sync: `getRoles`/`getGroups` shown as `Set` (actual `List`); non-existent `getAttributeValue`; `AuthenticationFacade` shows `login`/`getCurrentUser`/`void logout` — real API is `retrieveCurrentAuthenticationContext(...)` + `boolean logout(...)`. | Rewrite snippets to match the interfaces. |
+| D-4 | MEDIUM/HIGH | `modules/authentication/portal-authentication-oauth/README.adoc` | `.adoc` file uses **Markdown** headings (`#`, `##`) mixed with AsciiDoc `===`; sections don't render and there is no title. | Convert `#`→`=`, `##`→`==`. |
+| D-5 | MEDIUM | root `README.adoc:27` | BOM snippet pins `<version>1.4.0</version>`; reactor is `1.5-SNAPSHOT`. | Bump or drop the hard-coded version. |
+| D-6 | MEDIUM | all 8 `src/site/asciidoc/about.adoc` + 3 missing | Every `about.adoc` is a byte-identical stub ("Some information about this project"); `portal-common-cdi`, `portal-mp-rest-client`, `portal-core-unit-testing` have none. Root README links the root stub as "Generated Documentation". | Populate (they feed the Maven site) or stop generating and remove the dead link. |
+| D-7 | MEDIUM | `metrics-api/doc/LogMessages.md` | Fabricated WARN/ERROR entries (= M-6). | Remove (or reconcile with PR-6). |
+| D-8 | HIGH | `oauth/doc/LogMessages.md:40-48` | ERROR ids 203-211 in the doc are all wrong because code has duplicate 201/202 (G-1). Templates truncated for WARN-100/114, ERROR-207. | Regenerate after PR-9/G-1; restore full templates. |
+| D-9 | MEDIUM | `mock/doc/LogMessages.md` | Missing the `DEBUG.DEFAULT_USER_INFO_CREATED` (501) entry; format line has stray brackets `[MOCK-AUTH]-[identifier]`. | Add the DEBUG table row; fix the format line. |
+| D-10 | LOW | `portal-core-unit-testing/README.adoc:1` | Title `= portal-unit-testing-junit5` ≠ artifactId `portal-core-unit-testing`. | Align the title. |
+| D-11 | LOW | `portal-configuration` LogMessages/README + naming | `PortalConfigurationMessages` class breaks the `…LogMessages` naming convention used by every other module; a few doc templates drop trailing periods (101/110/160/161). | Optional rename for consistency; sync trailing punctuation. |
+| D-12 | LOW | multiple `impl`/test packages | Missing `package-info.java` for several packages (mostly internal/impl). | Add where rendered package docs are wanted (impl low priority). |
+
+---
+
+### PR-11 — Build / POM / CI hygiene  · **P2**
+Rebase on top of #132/#133 (parent 1.4.5) once merged.
+
+| # | Sev | File:line | Finding | Fix hint |
+|---|-----|-----------|---------|----------|
+| B-1 | MEDIUM | `pom.xml:33-35` | `maven.compiler.release` is a **dead no-op** — the parent compiler plugin reads `maven.compiler-plugin.release`. It "works" only because both are 21. | Remove the property, or set `maven.compiler-plugin.release` to actually override. |
+| B-2 | MEDIUM | `.github/project.yml:4` | `release.current-version: 1.4.0` is stale (parent 1.4.4, dev 1.5-SNAPSHOT); can skew changelog/range derivation. | Set to the last released portal version. |
+| B-3 | MEDIUM | `modules/micro-profile/pom.xml:8`; `portal-metrics-api/pom.xml:5`; `portal-mp-rest-client/pom.xml:4`; `bom/pom.xml:62,68`; `oauth/pom.xml:44` | **Published groupId typo `de.cuioss.portal.mirco-profile`** ("mirco"). Consistent everywhere so it builds, but it's a public coordinate; fixing later is a breaking change. **Maintainer decision — best done pre-1.5.** | Rename to `de.cuioss.portal.micro-profile` across parent/children/BOM/referrers and the two READMEs (D-2). Coordinate as one atomic change. |
+| B-4 | LOW | `portal-common-cdi/pom.xml:24-28`; `portal-configuration/pom.xml:83-87`; `portal-core/pom.xml:62-66`; `portal-mp-rest-client/pom.xml:82-86` | Redundant `junit-jupiter-params` (already transitive via the `junit-jupiter` aggregator). | Drop the explicit entries where the aggregator is present. |
+| B-5 | LOW | metrics-api, oauth, `authentication/pom.xml` (various) | Test-only deps carry no `<scope>` and sit among compile deps, resolving to `test` only via managed scope — intent invisible. | Add explicit `<scope>test</scope>` for readability (no resolution change). |
+| B-6 | LOW | mixed across sibling module POMs | Inconsistent explicit scopes; redundant `<scope>compile</scope>` (e.g. `portal-mp-rest-client/pom.xml:16-20`). | Standardise. |
+| B-7 | LOW | `.editorconfig:11-15` vs several POMs | `.editorconfig` mandates 4-space XML indent; several POMs use 2 spaces; mixed `http`/`https` schemaLocation. | Reformat POMs (or relax the rule); normalise to `https`. |
+| B-8 | LOW | `.mvn/wrapper/maven-wrapper.properties` | No `distributionSha256Sum` (supply-chain gap); Maven 3.9.6 trails current 3.9.x. | Pin the distribution SHA; consider bumping. |
+| B-9 | LOW | `.github/workflows/dependabot-auto-merge.yml:4-14` | Forwards `contents/pull-requests: write` on every `pull_request`; dependabot gating is delegated to the reusable workflow. | Add `if: github.actor == 'dependabot[bot]'` at the caller as defence-in-depth. |
+| B-10 | LOW | `portal-configuration/pom.xml:45-48` (via parent BOM) | `httpcore` is the maintenance-only 4.x line (HttpCore5 is current). 4.4.16 not known-vulnerable. | Track migration to `httpcore5` (parent-BOM decision). |
+| B-11 | LOW | `bom/pom.xml:12-81` | Published BOM manages only the 10 portal modules, not the third-party BOMs `modules/pom.xml` imports; consumers relying on the BOM alone won't get aligned Jakarta/MP versions. | Import third-party BOMs into `bom/pom.xml`, or document that consumers must also inherit `cui-java-parent`. |
+
+---
+
+## 3. Findings inventory (counts)
+
+| Severity | Count | Notable items |
+|---|---|---|
+| **HIGH** | 10 | S-1 (state/CSRF), S-2 (client secret log), L-1 (config secret log), M-1 (broken cache metrics), M-6/D-8 (fabricated & wrong log docs), C-1 (FileWatcher visibility), C-2 (disabled tests), K-1 (broken `Optional` contract), T-1 (failing/fragile test), T-2/#121 (flaky test), D-2 (wrong published groupId in docs) |
+| **MEDIUM** | ~26 | token logging, base64url, NPEs, ENTRY_CREATE, lazy-init races, doc/behavior mismatches, groupId typo, dead compiler property, stale release version |
+| **LOW** | ~40 | hygiene, cosmetics, doc gaps, defensive hardening |
+
+**Clean (no action):** deprecated-API debt, empty/swallowing catches, `System.out/err`/`printStackTrace`, log string-concatenation, license headers, committed secrets, hardcoded prod URLs/paths, dependency-version centralisation, action SHA-pinning, CI permissions blocks.
+
+---
+
+## 4. Suggested execution order
+
+1. **PR-1**, **PR-2** — P0 security; block the 1.5 release on these.
+2. **PR-6** (broken metrics), **PR-3** (FileWatcher + disabled tests), **PR-8** (get CI deterministically green) — in parallel.
+3. **PR-4**, **PR-5** — correctness cleanups, in parallel.
+4. **PR-9** → **PR-10** — log-id dedupe then doc regeneration (ordered).
+5. **PR-7** (test infra), **PR-11** (build/POM; rebase on #132/#133). Decide **B-3 groupId rename** before cutting 1.5.
+
+Each PR should: keep to its module/file scope above; add or restore tests that would have caught the bug (esp. S-1, S-4, S-5, M-1, C-1/C-2, K-1); and run `./mvnw clean verify -Ppre-commit` green (note the T-1 hostname caveat in constrained environments).


### PR DESCRIPTION
## Summary

Adds `doc/review-26-07-04.md` — a full, multi-dimensional review of the project and a prioritised remediation plan. **This PR is documentation only**; it changes no production code. The actual fixing is intended to follow as the partitioned PRs described in the plan.

### How the review was produced
Six parallel deep-review passes (authentication, core, micro-profile/test-infra, documentation, build/CI/dependencies, cross-cutting) plus a full `./mvnw clean verify -Ppre-commit` ground-truth build. The headline security findings were re-verified against source before inclusion.

### Headline findings
- **P0 security** — OAuth `state` (CSRF) is not enforced on the callback (login proceeds on mismatch); client secret and tokens leak into logs via Lombok `@Data` `toString`; `PortalConfigurationLogger` redaction misses uppercase/`secret`/`token` keys; REST-client filters log `Authorization` headers.
- **P1 correctness** — Caffeine cache stat gauges are pinned to a zero snapshot (metrics effectively broken); `FileWatcherServiceImpl` shutdown flag is non-`volatile` and its async tests are `@Disabled`; `PortalBeanManager`'s documented `Optional.empty()` path is unreachable.
- **Test reliability** — `HostnameVerificationTest.incorrectHostname` fails in containerised environments (env-fragile `assertNotEquals("localhost", …)`, and misnamed); flaky `ExternalHostnameProducerTest` (#121).
- **Docs/build** — LogMessages docs drift from code (fabricated metrics entries; OAuth duplicate log ids cascade wrong ids into the docs); missing `portal-configuration` in the core README; wrong/typo'd published groupId (`mirco-profile`); a dead `maven.compiler.release` property.

The codebase is otherwise notably disciplined: no `TODO`/`FIXME`, no `@Deprecated` debt, no `System.out`/`printStackTrace`, full license-header coverage, no committed secrets, fully centralised dependency versions, and SHA-pinned CI actions.

### Plan structure
Findings are partitioned into **11 independently-mergeable PR clusters** (P0 security first), with severities, `file:line` anchors, fix hints, an execution order, and cross-references to issue #121 and the pending parent-POM bump (#132/#133).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0113BCRpgispqcSCd8ecFzMY

---
_Generated by [Claude Code](https://claude.ai/code/session_0113BCRpgispqcSCd8ecFzMY)_